### PR TITLE
chore: website language update

### DIFF
--- a/site/src/app/(v2)/(marketing)/(index)/sections/HeroSection.tsx
+++ b/site/src/app/(v2)/(marketing)/(index)/sections/HeroSection.tsx
@@ -16,7 +16,7 @@ export function HeroSection() {
 						<h1 className="hero-bg-exclude text-4xl md:text-5xl font-normal text-white leading-[1.3] sm:leading-[1.1] tracking-[-0.03em] max-w-full">
 							{/*Lightweight library for building modern backends*/}
 							{/*Library for building stateful applications and distributed systems*/}
-							The open-source alternative to Durable Objects
+							Build and scale stateful workloads
 						</h1>
 
 						<div className="h-5" />

--- a/site/src/app/(v2)/(marketing)/(index)/sections/StudioSection.tsx
+++ b/site/src/app/(v2)/(marketing)/(index)/sections/StudioSection.tsx
@@ -90,7 +90,7 @@ export function StudioSection() {
 					{/* Header */}
 					<div className="max-w-7xl mx-auto relative z-20 pointer-events-auto">
 						<h2 className="max-w-lg text-4xl font-medium tracking-tight text-white">
-							Supercharged Local Development with the Studio
+							Supercharged Local Development with the Inspector
 						</h2>
 						<p className="max-w-lg mt-4 text-lg text-white/70">
 							Like Postman, but for all of your stateful serverless needs.
@@ -104,7 +104,7 @@ export function StudioSection() {
 								target="_blank"
 								rel="noopener noreferrer"
 							>
-								Visit The Studio
+								Visit The Inspector
 								<span className="transition-transform group-hover/link:translate-x-1">→</span>
 							</a>
 						</div>

--- a/site/src/components/v2/GitHubDropdown.tsx
+++ b/site/src/components/v2/GitHubDropdown.tsx
@@ -128,7 +128,7 @@ export function GitHubDropdown({ className, ...props }: GitHubDropdownProps) {
 										)}
 									/>
 									<div className="flex flex-col items-start">
-										<span className="font-medium">Rivet</span>
+										<span className="font-medium">Engine</span>
 										<span
 											className={cn(
 												"text-xs",
@@ -137,7 +137,7 @@ export function GitHubDropdown({ className, ...props }: GitHubDropdownProps) {
 													: "text-muted-foreground",
 											)}
 										>
-											Stateful workload orchestrator
+											Orchestrator for RivetKit
 										</span>
 										<span
 											className={cn(


### PR DESCRIPTION
### TL;DR

Updated marketing copy on the homepage to better reflect product positioning and naming.

### What changed?

- Changed the hero section headline from "The open-source alternative to Durable Objects" to "Build and scale stateful workloads"
- Renamed "Studio" to "Inspector" in the StudioSection component
- Updated GitHub dropdown text, changing "Rivet" to "Engine" and its description from "Stateful workload orchestrator" to "Orchestrator for RivetKit"